### PR TITLE
Add explicit 2.0 style privilege escalation

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   company: Kitware, Inc.
 
   license: Apache
-  min_ansible_version: 1.4
+  min_ansible_version: 1.9
 
   platforms:
   - name: Ubuntu

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -17,10 +17,12 @@ galaxy_info:
 dependencies:
   - role: nodesource.node
     nodejs_version: "4.4"
-    sudo: yes
+    become: yes
+    become_user: root
   - role: Stouts.mongodb
     mongodb_version: "3.2"
     mongodb_conf_cpu: no
     mongodb_conf_dbpath: "/var/lib/mongodb"
     mongodb_conf_journal: yes
-    sudo: yes
+    become: yes
+    become_user: root

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,7 +4,8 @@
 - name: Install Girder system dependencies
   apt:
     name: "{{ item }}"
-  sudo: yes
+  become: yes
+  become_user: root
   with_items:
     - git
     - libffi-dev
@@ -18,7 +19,8 @@
   pip:
     name: pip
     state: latest
-  sudo: yes
+  become: yes
+  become_user: root
 
 - name: Download Girder
   git:
@@ -32,4 +34,5 @@
 - name: Install Girder Python dependencies
   pip:
     requirements: "{{ girder_path }}/requirements.txt"
-  sudo: yes
+  become: yes
+  become_user: root


### PR DESCRIPTION
"Become" syntax is compatible with ansible 1.9.x forward. Adding
become_user is nessisary so that the role may be called with a seperate
user, e.g.:

``` yaml
- role: girder.girder
  become: yes
  become_user: "girder"
```

Assuming the girder user has been created.  Otherwise ansible's internal
logic will assume all "become" statements refer to the value of the
become_user statement (which only defaults to root).
