### PR TITLE
Change mongo version string ("3.2" -> "3.2.0")

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -20,7 +20,7 @@ dependencies:
     become: yes
     become_user: root
   - role: Stouts.mongodb
-    mongodb_version: "3.2"
+    mongodb_version: "3.2.0"
     mongodb_conf_cpu: no
     mongodb_conf_dbpath: "/var/lib/mongodb"
     mongodb_conf_journal: yes

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -16,7 +16,7 @@ galaxy_info:
 
 dependencies:
   - role: nodesource.node
-    nodejs_version: "4.4"
+    nodejs_version: "4.5.0"
     become: yes
     become_user: root
   - role: Stouts.mongodb


### PR DESCRIPTION
It seems the repository has changed its version string such that
'apt-get install mongodb-org=3.2' no longer works,  but 'apt-get install
mongodb-org=3.2.0' does.
