### PR TITLE
Update apt cache prior to installing packages

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,6 +6,7 @@
       - python3-setuptools
       - python3-dev
     force_apt_get: true
+    update_cache: true
   become: true
   become_user: root
 


### PR DESCRIPTION
This role wouldn't work in a standalone way currently on Ubuntu 18.04. Without updating the cache, the listed packages cannot be installed. Our prod installation accidentally avoids this simply because it installs the mongo role first.